### PR TITLE
Add tuning properties

### DIFF
--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -247,3 +247,7 @@ properties:
   cf_mysql.mysql.enable_galera:
     default: true
     description: 'Advanced feature. Only use this when deploying a single MySQL node with no intention to run any other components of cf-mysql-release.'
+
+  cf_mysql.mysql.long_query_time:
+    default: 30
+    description: 'If a query takes longer than this many seconds, the server increments the Slow_queries status variable. If the slow query log is enabled, the query is logged to the slow query log file'

--- a/jobs/mysql/spec
+++ b/jobs/mysql/spec
@@ -251,3 +251,8 @@ properties:
   cf_mysql.mysql.long_query_time:
     default: 30
     description: 'If a query takes longer than this many seconds, the server increments the Slow_queries status variable. If the slow query log is enabled, the query is logged to the slow query log file'
+
+  cf_mysql.mysql.performance_schema:
+    default: OFF
+    description: 'Indicate whether Performance Schema is enabled'
+    

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -196,6 +196,45 @@ max_connections                 = <%= p('cf_mysql.mysql.max_connections') %>
 # Event Scheduler
 event_scheduler                 = <%= p('cf_mysql.mysql.event_scheduler') %>
 
+performance_schema              = <%= p('cf_mysql.mysql.performance_schema') %>
+<% if p('cf_mysql.mysql.performance_schema') %>
+# Specifies the maximum number of each instrument
+performance_schema_max_cond_classes                    = 80
+performance_schema_max_file_classes                    = 50
+performance_schema_max_mutex_classes                   = 200
+performance_schema_max_rwlock_classes                  = 40
+performance_schema_max_socket_classes                  = 10
+performance_schema_max_stage_classes                   = 150
+performance_schema_max_statement_classes               = 168
+performance_schema_max_thread_classes                  = 50
+# indicates how many different users, hosts, or accounts (combinations of 'user_name'@'host_name') are expected to connect to the server.
+performance_schema_accounts_size                       = 100
+performance_schema_hosts_size                          = 100
+performance_schema_users_size                          = 100
+# affect directly how much memory is used to keep historical data, but have no impact on CPU. 
+performance_schema_events_stages_history_long_size     = 1000
+performance_schema_events_stages_history_size          = 10
+performance_schema_events_statements_history_long_size = 1000
+performance_schema_events_statements_history_size      = 10
+performance_schema_events_waits_history_long_size      = 10000
+performance_schema_events_waits_history_size           = 10
+#
+performance_schema_max_cond_instances                  = 1258
+performance_schema_max_file_handles                    = 32768
+performance_schema_max_file_instances                  = 6250
+performance_schema_max_mutex_instances                 = 5133 
+performance_schema_max_rwlock_instances                = 2765
+performance_schema_max_table_handles                   = 366
+performance_schema_max_table_instances                 = 587
+performance_schema_max_socket_instances                = 230
+performance_schema_max_thread_instances                = 288
+#
+performance_schema_setup_actors_size                   = 100
+performance_schema_setup_objects_size                  = 100
+performance_schema_session_connect_attrs_size          = 512
+performance_schema_digests_size                        = 5000
+<% end %>    
+
 [mysqldump]
 quick
 quote-names

--- a/jobs/mysql/templates/my.cnf.erb
+++ b/jobs/mysql/templates/my.cnf.erb
@@ -118,6 +118,7 @@ log_bin_trust_function_creators = 1
 # Slow query logging:
 slow_query_log                  = 1
 slow_query_log_file             = /var/vcap/sys/log/mysql/mysql_slow_query.log
+long_query_time                 = <%= p('cf_mysql.mysql.long_query_time') %>
 <% if p('cf_mysql.mysql.log_queries_not_using_indexes') %>
 log_queries_not_using_indexes   = ON
 <% end %>


### PR DESCRIPTION
Optimizations for tuning a MySQL instance :
  - add a long_query_time property to adjust the value at best and log it in the slow queries file. By default, 10s is too long for a transactional type application. The value can be specified to a resolution of microseconds.
  - possibility to activate performance_schema (FALSE by default). The MySQL Performance Schema is a feature for monitoring MySQL Server execution at a low level, and prometheus use it ([mysql_exporter](https://github.com/prometheus/mysqld_exporter) metrics `collect.perf_schema`). 

Performance_schema use memory engine, so if you active it, you can verify with : 
```
 SHOW ENGINE PERFORMANCE_SCHEMA STATUS   ;
+--------------------+--------------------------------------------------------------+----------+
| Type               | Name                                                         | Status   |
+--------------------+--------------------------------------------------------------+----------+
..
| performance_schema | performance_schema.memory                                    | 68024448 |
+--------------------+--------------------------------------------------------------+----------+
```

Memory size depend of max_connections (150 in this example)
