### PR TITLE
add REPLICATION CLIENT privilege to user mysql roadmin

### DIFF
--- a/jobs/mysql/templates/mariadb_init.erb
+++ b/jobs/mysql/templates/mariadb_init.erb
@@ -27,7 +27,7 @@ GRANT ALL PRIVILEGES ON *.* TO '<%= p('cf_mysql.mysql.admin_username') %>'@'<%= 
   <% if p('cf_mysql.mysql.roadmin_enabled') %>
 CREATE USER IF NOT EXISTS 'roadmin'@'<%= host %>' IDENTIFIED BY '<%= p('cf_mysql.mysql.roadmin_password') %>';
 SET PASSWORD FOR 'roadmin'@'<%= host %>' = PASSWORD('<%= p('cf_mysql.mysql.roadmin_password') %>');
-GRANT SELECT, PROCESS ON *.* TO 'roadmin'@'<%= host %>';
+GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'roadmin'@'<%= host %>';
   <% end %>
 <% end %>
 


### PR DESCRIPTION
For prometheus `mysqld_exporter`, we use `roadmin@localhost `user mysql (better than `root@localhost`). `mysqld_exporter` needs  `REPLICATION CLIENT` privilege to monitor binlogs size.

Without this privilege we have error messages in mysql_exporter log, such as: 

> time="2017-09-28T12:19:57Z" level=error msg="Error scraping for collect.binlog_size: Error 1227: Access denied; you need (at least one of) the SUPER, REPLICATION CLIENT privilege(s) for this operation" source="mysqld_exporter.go:335"

The `REPLICATION CLIENT` privilege enables the use of the `SHOW MASTER STATUS`, `SHOW SLAVE STATUS`, and `SHOW BINARY LOGS` statements.
